### PR TITLE
decode url params so spaces and other types of chars are properly interpreted

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function params(pattern, url) {
   var hash = {};
 
   for (var n = 0; n < vars.length; ++n) {
-    hash[vars[n]] = routeMatch[n + 1];
+    hash[vars[n]] = decodeURIComponent(routeMatch[n + 1]);
   }
 
   var queryString = routeMatch[vars.length + 2];

--- a/test/routerSpec.js
+++ b/test/routerSpec.js
@@ -96,6 +96,20 @@ describe("router", function() {
     });
   });
 
+  it("can get a url with spaces in the params", function(){
+    var router = createRouter();
+    router.get("/path/:name", function(req){
+      console.log(req.params.name);
+      return {
+        body: req.params.name
+      }
+    });
+
+    return http.get("/path/with%20space").then(function(response){
+      expect(response.body).to.equal('with space');
+    });
+  });
+
   it("can post JSON", function() {
     var router = createRouter();
 


### PR DESCRIPTION
route '/hello/:name'
url '/hello/joe bloggs'

`req.params.name == 'joe%20bloggs'`

this change decodes it so that it would be:

`req.params.name == 'joe bloggs'`
